### PR TITLE
[CM-1180] Don't use Date.now()

### DIFF
--- a/src/calls.ts
+++ b/src/calls.ts
@@ -30,11 +30,11 @@ export class DefaultCallHandler implements CallHandler {
     }
 
     try {
-      const startTime = Date.now()
+      const startTime = (new Date()).getTime()
       const request = (window && window.XDomainRequest) ? xdrCall() : xhrCall()
 
       request.ontimeout = () => {
-        const duration = Date.now() - startTime
+        const duration = (new Date()).getTime() - startTime
         errorCallback(`Timeout after ${duration} (${timeout}), url: ${url}`)
       }
       request.open('GET', url, true)

--- a/src/storage.ts
+++ b/src/storage.ts
@@ -51,7 +51,7 @@ export class DefaultStorageHandler implements StorageHandler {
       if (typeof expires === 'string') {
         expiresDate = new Date(expires)
       } else if (typeof expires === 'number') {
-        expiresDate = new Date(Date.now() + expires * 864e5)
+        expiresDate = new Date((new Date()).getTime() + expires * 864e5)
       } else {
         expiresDate = expires
       }


### PR DESCRIPTION
# [CM-1180](https://liveintent.atlassian.net/browse/CM-1180)

Date.now() is getting redefined on one of the sites we are deploying to.

Author Todo List:

- [x] Add/adjust tests (if applicable)
- [x] Build in CI passes
- [x] Latest master revision is merged into the branch
- [x] Self-Review
- [x] Set `Ready For Review` status


[CM-1180]: https://liveintent.atlassian.net/browse/CM-1180?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ